### PR TITLE
Fix docs text in Work section

### DIFF
--- a/src/lib/Work.svelte
+++ b/src/lib/Work.svelte
@@ -38,8 +38,8 @@
         {
             id: 2,
             title: "Fontys Internal Post Platform (FIPost)",
-            body: "An opensource project that aims to modernise the internal post system of Fontys tracking and scanning packages. This is a multi year long term project with me as the head maintainer.",
-            stack: "C#, .NET6, postgre  SQL, Vue.js, TypeScript, SCSS, Azure, K8s, rabbitMQ, Cypress, SonarCloud",
+            body: "An open-source project that aims to modernise the internal post system of Fontys tracking and scanning packages. This is a multi year long term project with me as the head maintainer.",
+            stack: "C#, .NET6, PostgreSQL, Vue.js, TypeScript, SCSS, Azure, K8s, rabbitMQ, Cypress, SonarCloud",
             banner: iPostBanner,
             isVideo: true,
             logo: iPost,


### PR DESCRIPTION
## Summary
- fix typos in `Work.svelte` description

## Testing
- `npm run check` *(fails: svelte-check not found)*

------
https://chatgpt.com/codex/tasks/task_e_68762eb248e48326b3033766327ae7d9